### PR TITLE
Fixed implode for php 7.4

### DIFF
--- a/resources/views/admin/includes/avatar-uploader.blade.php
+++ b/resources/views/admin/includes/avatar-uploader.blade.php
@@ -9,7 +9,7 @@
         :max-file-size-in-mb="{{ round(($mediaCollection->getMaxFileSize()/1024/1024), 2) }}"
         @endif
         @if($mediaCollection->getAcceptedFileTypes())
-        :accepted-file-types="'{{ implode($mediaCollection->getAcceptedFileTypes(), '') }}'"
+        :accepted-file-types="'{{ implode('', $mediaCollection->getAcceptedFileTypes()) }}'"
         @endif
         @if(isset($media) && $media->count() > 0)
         :uploaded-images="{{ $media->toJson() }}"

--- a/resources/views/admin/includes/media-uploader.blade.php
+++ b/resources/views/admin/includes/media-uploader.blade.php
@@ -32,7 +32,7 @@
 			:max-file-size-in-mb="{{ round(($mediaCollection->getMaxFileSize()/1024/1024), 2) }}"
 		@endif
 		@if($mediaCollection->getAcceptedFileTypes())
-			:accepted-file-types="'{{ implode($mediaCollection->getAcceptedFileTypes(), '') }}'"
+			:accepted-file-types="'{{ implode('', $mediaCollection->getAcceptedFileTypes()) }}'"
 		@endif
 		@if(isset($media) && $media->count() > 0)
 			:uploaded-images="{{ $media->toJson() }}"


### PR DESCRIPTION
Switch parameters in implode to be compatible with php 7.4 (implode() can, for historical reasons, accept its parameters in either order. For consistency with explode(), however, it is deprecated not to use the documented order of arguments.)