### PR TITLE
chore: added vue-loader to parse vue files from node_modules

### DIFF
--- a/install-stubs/webpack.mix.js
+++ b/install-stubs/webpack.mix.js
@@ -1,6 +1,8 @@
-mix.js(['resources/js/admin/admin.js'], 'public/js')
-    .sass('resources/sass/admin/admin.scss', 'public/css');
+mix
+  .js(["resources/js/admin/admin.js"], "public/js")
+  .sass("resources/sass/admin/admin.scss", "public/css")
+  .vue();
 
 if (mix.inProduction()) {
-    mix.version();
+  mix.version();
 }


### PR DESCRIPTION
fixes https://github.com/BRACKETS-by-TRIAD/craftable/issues/308

The issue above is related to error during `npm run dev` which loads uncompiled .vue files from node_modules. 
