### PR TITLE
added: local devDependencies for craftable project

### DIFF
--- a/src/Console/Commands/AdminUIInstall.php
+++ b/src/Console/Commands/AdminUIInstall.php
@@ -71,6 +71,11 @@ class AdminUIInstall extends Command
         $packageJson = $files->get($packageJsonFile);
         $packageJsonContent = json_decode($packageJson, JSON_OBJECT_AS_ARRAY);
         $packageJsonContent['devDependencies']['craftable'] = '^2.1.3';
+
+        $packageJsonContent['devDependencies']['vue-loader'] = '^15.9.6';
+        $packageJsonContent['devDependencies']['sass-loader'] = '^8.0.2';
+        $packageJsonContent['devDependencies']['resolve-url-loader'] = '^3.1.0';
+
         $files->put($packageJsonFile, json_encode($packageJsonContent, JSON_PRETTY_PRINT));
         $this->info('package.json changed');
     }


### PR DESCRIPTION
These devDeps are missing from local project. Having them will remove installation error in which laravel mix fails