### PR TITLE
Remove 'type' from default package.json

### DIFF
--- a/src/Console/Commands/AdminUIInstall.php
+++ b/src/Console/Commands/AdminUIInstall.php
@@ -83,6 +83,7 @@ class AdminUIInstall extends Command
         $packageJsonContent['devDependencies']['sass-loader'] = '^8.0.2';
         $packageJsonContent['devDependencies']['resolve-url-loader'] = '^3.1.0';
         $packageJsonContent['devDependencies']['sass'] = '^1.32.6';
+        unset($packageJsonContent['module']);
 
         $files->put($packageJsonFile, json_encode($packageJsonContent, JSON_PRETTY_PRINT));
         $this->info('package.json changed');


### PR DESCRIPTION
Laravel added default "type": "module" to their package.json in PR: https://github.com/laravel/vite-plugin/pull/189. This breaks compilation with laravel-mix and therefore we need to remove this line from package.json in the installation process. The ability to compile with Vite shouldn't be affected by this, however some specific modules (like svelte) can be affected by this, as mentioned in the Laravel's PR. We think that the potential problem with specific libraries should be resolved by developer that uses them.